### PR TITLE
feat: add possibility to convert object to maps and back

### DIFF
--- a/core/src/main/java/de/drolpi/conversion/core/AlgorithmConversionBus.java
+++ b/core/src/main/java/de/drolpi/conversion/core/AlgorithmConversionBus.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2023-2024 Lars Nippert
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.drolpi.conversion.core;
+
+import de.drolpi.conversion.core.converter.NonGenericConverter;
+import de.drolpi.conversion.core.exception.ConversionFailedException;
+import de.drolpi.conversion.core.util.ClassCollectorUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+class AlgorithmConversionBus extends BasicConversionBus {
+
+    public AlgorithmConversionBus() {
+        super(new AlgorithmConverterRegistrar());
+    }
+
+    private static final class AlgorithmConverterRegistrar extends ConverterRegistrar {
+
+        @Override
+        protected NonGenericConverter find(@NotNull Type sourceType, @NotNull Type targetType) {
+            // Try to find an explicitly registered converter
+            final NonGenericConverter converter = super.find(sourceType, targetType);
+            if (converter != null) {
+                return converter;
+            }
+
+            final AlgorithmResult result = new AlgorithmResult();
+            final AlgorithmPath emptyPath = new AlgorithmPath();
+            this.algorithm(sourceType, targetType, emptyPath, result);
+
+            if (result.isEmpty()) {
+                return null;
+            }
+            // Sort so that we start with the shortest path
+            result.sort(Comparator.comparingInt(List::size));
+
+            return new AlgorithmConverter(result);
+        }
+
+        private void algorithm(Type source, Type target, AlgorithmPath previousPath, AlgorithmResult result) {
+            // Search the whole type tree
+            final List<Class<?>> sourceTree = ClassCollectorUtil.classTree(source);
+            final List<Class<?>> targetTree = ClassCollectorUtil.classTree(target);
+
+            // Iterate through the whole class tree to find a converter with a matching source type
+            for (final Class<?> sourceCandidate : sourceTree) {
+                // Iterate through all registered converters
+                for (final Map.Entry<NonGenericConverter.ConversionPath, Deque<NonGenericConverter>> entry : this.converters.entrySet()) {
+                    final NonGenericConverter.ConversionPath path = entry.getKey();
+                    // Skip if the source type does not match
+                    if (path.sourceType() != sourceCandidate) {
+                        continue;
+                    }
+                    // Skip if we already have this converter in our path to avoid going round in circles
+                    if (previousPath.contains(entry.getValue())) {
+                        continue;
+                    }
+                    // Create a new path, as we have multiple options here
+                    final AlgorithmPath nextPath = new AlgorithmPath(previousPath);
+                    nextPath.add(entry.getValue());
+
+                    // Iterate through the entire class tree to check whether we are already at the end and the target type of the converter matches
+                    for (final Class<?> targetCandidate : targetTree) {
+                        if (!path.targetType().equals(targetCandidate)) {
+                            continue;
+                        }
+                        result.add(nextPath);
+                        return;
+                    }
+
+                    // Skip if the maximum depth is reached
+                    if (nextPath.size() == 5) {
+                        continue;
+                    }
+
+                    // Call recursive
+                    this.algorithm(path.targetType(), target, nextPath, result);
+                }
+            }
+        }
+    }
+
+    private record AlgorithmConverter(AlgorithmResult result) implements NonGenericConverter {
+
+        @Override
+        public @Nullable Object convert(@Nullable Object source, @NotNull Type sourceType, @NotNull Type targetType) {
+            // Iterate through all the possibilities to try them out
+            for (final AlgorithmPath path : this.result) {
+                try {
+                    // Try path
+                    return this.tryConvert(path, source, sourceType, targetType);
+                } catch (Exception ignored) {
+                    // Do nothing because the next path will be tried
+                }
+            }
+
+            throw new ConversionFailedException(sourceType, targetType, source);
+        }
+
+        private Object tryConvert(AlgorithmPath path, Object source, Type sourceType, Type targetType) {
+            Object result = source;
+
+            // Iterate through all ways of the path
+            for (int i = 0; i < path.size(); i++) {
+                final Deque<NonGenericConverter> converterDeque = path.get(i);
+
+                //TODO: Can a converter generate a value other than null from the source null? Currently not!
+                if (result == null) {
+                    return null;
+                }
+
+                // Iterate through all possible converters of the way to check their conditions
+                for (final NonGenericConverter nonGenericConverter : converterDeque) {
+                    final Type sourceT = result.getClass();
+                    Type targetT = targetType;
+                    boolean suitable = false;
+
+                    // Iterate through all suitable paths to check whether one of them is suitable
+                    for (final ConversionPath conversionPath : nonGenericConverter.paths()) {
+                        // If this is not the last converter, set the intermediate target type
+                        if ((i + 1) != path.size()) {
+                            targetT = conversionPath.targetType();
+                        }
+
+                        if (nonGenericConverter.isSuitable(sourceType, targetT)) {
+                            suitable = true;
+                            break;
+                        }
+                    }
+
+                    if (suitable) {
+                        result = nonGenericConverter.convert(result, sourceT, targetT);
+                        break;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        @Override
+        public @NotNull Set<ConversionPath> paths() {
+            return Set.of();
+        }
+
+        @Override
+        public boolean isSuitable(@NotNull Type sourceType, @NotNull Type targetType) {
+            return true;
+        }
+    }
+
+    private static class AlgorithmResult extends ArrayList<AlgorithmPath> {
+
+    }
+
+    private static class AlgorithmPath extends ArrayList<Deque<NonGenericConverter>> {
+
+        public AlgorithmPath() {
+
+        }
+
+        public AlgorithmPath(@NotNull Collection<? extends Deque<NonGenericConverter>> c) {
+            super(c);
+        }
+    }
+}

--- a/core/src/main/java/de/drolpi/conversion/core/ConversionBus.java
+++ b/core/src/main/java/de/drolpi/conversion/core/ConversionBus.java
@@ -16,6 +16,7 @@
 
 package de.drolpi.conversion.core;
 
+import io.leangen.geantyref.TypeToken;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Type;
@@ -30,6 +31,14 @@ public interface ConversionBus {
         return new DefaultConversionBus();
     }
 
+    static @NotNull ConfigurableConversionBus createAlgorithm() {
+        return new AlgorithmConversionBus();
+    }
+
+    static @NotNull ConfigurableConversionBus createAlgorithmDefault() {
+        return new DefaultAlgorithmConversionBus();
+    }
+
     @NotNull Object convert(@NotNull Object source, @NotNull Type targetType);
 
     @SuppressWarnings("unchecked")
@@ -37,4 +46,8 @@ public interface ConversionBus {
         return (T) this.convert(source, (Type) targetType);
     }
 
+    @SuppressWarnings("unchecked")
+    default <T> T convert(@NotNull Object source, @NotNull TypeToken<T> typeToken) {
+        return (T) this.convert(source, typeToken.getType());
+    }
 }

--- a/core/src/main/java/de/drolpi/conversion/core/DefaultAlgorithmConversionBus.java
+++ b/core/src/main/java/de/drolpi/conversion/core/DefaultAlgorithmConversionBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2023 Lars Nippert
+ * Copyright 2023-2024 Lars Nippert
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,9 @@
 
 package de.drolpi.conversion.core;
 
-import de.drolpi.conversion.core.converter.Converter;
-import de.drolpi.conversion.core.converter.NonGenericConverter;
-import org.jetbrains.annotations.NotNull;
+public class DefaultAlgorithmConversionBus extends AlgorithmConversionBus {
 
-public interface ConverterRegistry {
-
-    <U, V> void register(@NotNull Class<? extends U> source, @NotNull Class<V> target, @NotNull Converter<U, V> converter);
-
-    void register(@NotNull NonGenericConverter converter);
-
-    void unregister(@NotNull Class<?> source, @NotNull Class<?> target);
-
-    void unregister(@NotNull NonGenericConverter converter);
+    public DefaultAlgorithmConversionBus() {
+        DefaultConversionBus.registerDefaults(this);
+    }
 }

--- a/core/src/main/java/de/drolpi/conversion/core/DefaultConversionBus.java
+++ b/core/src/main/java/de/drolpi/conversion/core/DefaultConversionBus.java
@@ -2,7 +2,7 @@
  * Copyright 2023-2023 Lars Nippert
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * you may not use bus file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
@@ -20,12 +20,15 @@ import de.drolpi.conversion.core.impl.BooleanToIntegerConverter;
 import de.drolpi.conversion.core.impl.EnumToIntegerConverter;
 import de.drolpi.conversion.core.impl.EnumToStringConverter;
 import de.drolpi.conversion.core.impl.IntegerToBooleanConverter;
+import de.drolpi.conversion.core.impl.IntegerToEnumConverter;
 import de.drolpi.conversion.core.impl.MapToMapConverter;
 import de.drolpi.conversion.core.impl.NumberToCharacterConverter;
+import de.drolpi.conversion.core.impl.NumberToNumberConverter;
 import de.drolpi.conversion.core.impl.ObjectToStringConverter;
 import de.drolpi.conversion.core.impl.StringToBooleanConverter;
 import de.drolpi.conversion.core.impl.StringToCharacterConverter;
 import de.drolpi.conversion.core.impl.StringToCurrencyConverter;
+import de.drolpi.conversion.core.impl.StringToEnumConverter;
 import de.drolpi.conversion.core.impl.StringToUriConverter;
 import de.drolpi.conversion.core.impl.StringToUrlConverter;
 import de.drolpi.conversion.core.impl.StringToUuidConverter;
@@ -42,43 +45,49 @@ import java.util.regex.Pattern;
 class DefaultConversionBus extends BasicConversionBus {
 
     public DefaultConversionBus() {
+        DefaultConversionBus.registerDefaults(this);
+    }
+    
+    public static void registerDefaults(ConfigurableConversionBus bus) {
         // Scalar converters
+        bus.register(Boolean.class, String.class, new ObjectToStringConverter());
+        bus.register(String.class, Boolean.class, new StringToBooleanConverter());
+        bus.register(Boolean.class, Integer.class, new BooleanToIntegerConverter());
+        bus.register(Integer.class, Boolean.class, new IntegerToBooleanConverter());
 
-        this.register(Boolean.class, String.class, new ObjectToStringConverter());
-        this.register(String.class, Boolean.class, new StringToBooleanConverter());
-        this.register(Boolean.class, Integer.class, new BooleanToIntegerConverter());
-        this.register(Integer.class, Boolean.class, new IntegerToBooleanConverter());
+        bus.register(Character.class, String.class, new ObjectToStringConverter());
+        bus.register(String.class, Character.class, new StringToCharacterConverter());
+        bus.register(Number.class, Character.class, new NumberToCharacterConverter());
 
-        this.register(Character.class, String.class, new ObjectToStringConverter());
-        this.register(String.class, Character.class, new StringToCharacterConverter());
-        this.register(Number.class, Character.class, new NumberToCharacterConverter());
+        bus.register(Charset.class, String.class, new ObjectToStringConverter());
+        bus.register(CharSequence.class, String.class, new ObjectToStringConverter());
+        bus.register(StringWriter.class, String.class, new ObjectToStringConverter());
 
-        this.register(Charset.class, String.class, new ObjectToStringConverter());
-        this.register(CharSequence.class, String.class, new ObjectToStringConverter());
-        this.register(StringWriter.class, String.class, new ObjectToStringConverter());
+        bus.register(Number.class, String.class, new ObjectToStringConverter());
+        bus.register(Number.class, Number.class, new NumberToNumberConverter());
 
-        this.register(Number.class, String.class, new ObjectToStringConverter());
+        bus.register(Currency.class, String.class, new ObjectToStringConverter());
+        bus.register(String.class, Currency.class, new StringToCurrencyConverter());
 
-        this.register(Currency.class, String.class, new ObjectToStringConverter());
-        this.register(String.class, Currency.class, new StringToCurrencyConverter());
+        bus.register(UUID.class, String.class, new ObjectToStringConverter());
+        bus.register(String.class, UUID.class, new StringToUuidConverter());
 
-        this.register(UUID.class, String.class, new ObjectToStringConverter());
-        this.register(String.class, UUID.class, new StringToUuidConverter());
+        bus.register(Pattern.class, String.class, new ObjectToStringConverter());
 
-        this.register(Pattern.class, String.class, new ObjectToStringConverter());
+        bus.register(Locale.class, String.class, new ObjectToStringConverter());
 
-        this.register(Locale.class, String.class, new ObjectToStringConverter());
+        bus.register(URL.class, String.class, new ObjectToStringConverter());
+        bus.register(String.class, URL.class, new StringToUrlConverter());
 
-        this.register(URL.class, String.class, new ObjectToStringConverter());
-        this.register(String.class, URL.class, new StringToUrlConverter());
+        bus.register(URI.class, String.class, new ObjectToStringConverter());
+        bus.register(String.class, URI.class, new StringToUriConverter());
 
-        this.register(URI.class, String.class, new ObjectToStringConverter());
-        this.register(String.class, URI.class, new StringToUriConverter());
-
-        this.register(Enum.class, String.class, new EnumToStringConverter());
-        this.register(Enum.class, Integer.class, new EnumToIntegerConverter());
+        bus.register(new EnumToStringConverter());
+        bus.register(new StringToEnumConverter());
+        bus.register(new EnumToIntegerConverter());
+        bus.register(new IntegerToEnumConverter());
 
         // Collection converters
-        this.register(new MapToMapConverter());
+        bus.register(new MapToMapConverter());
     }
 }

--- a/core/src/main/java/de/drolpi/conversion/core/converter/Converter.java
+++ b/core/src/main/java/de/drolpi/conversion/core/converter/Converter.java
@@ -34,6 +34,6 @@ public interface Converter<T, U>  {
      * @param source the source object to convert, which must be an instance of {@code S} (never {@code null})
      * @return the converted object, which must be an instance of {@code T} (potentially {@code null})
      */
-    @NotNull U convert(@NotNull T source, @NotNull Type sourceType, @NotNull Type targetType);
+    U convert(T source, @NotNull Type sourceType, @NotNull Type targetType);
 
 }

--- a/core/src/main/java/de/drolpi/conversion/core/converter/NonGenericConverter.java
+++ b/core/src/main/java/de/drolpi/conversion/core/converter/NonGenericConverter.java
@@ -17,10 +17,15 @@
 package de.drolpi.conversion.core.converter;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.Type;
 import java.util.Set;
 
 public interface NonGenericConverter extends ConditionalConverter<Object, Object> {
+
+    @Override
+    @Nullable Object convert(@Nullable Object source, @NotNull Type sourceType, @NotNull Type targetType);
 
     @NotNull Set<ConversionPath> paths();
 

--- a/core/src/main/java/de/drolpi/conversion/core/exception/ConversionFailedException.java
+++ b/core/src/main/java/de/drolpi/conversion/core/exception/ConversionFailedException.java
@@ -27,7 +27,7 @@ public class ConversionFailedException extends ConversionException {
 
     private final Object source;
 
-    public ConversionFailedException(@NotNull Type sourceType, @NotNull Type targetType, @NotNull Object source) {
+    public ConversionFailedException(@NotNull Type sourceType, @NotNull Type targetType, Object source) {
         super(sourceType, targetType, String.format("Failed to convert from type [%s] to type [%s] for value [%s]", sourceType, targetType, source));
         this.source = source;
     }

--- a/core/src/main/java/de/drolpi/conversion/core/impl/EnumToIntegerConverter.java
+++ b/core/src/main/java/de/drolpi/conversion/core/impl/EnumToIntegerConverter.java
@@ -16,15 +16,33 @@
 
 package de.drolpi.conversion.core.impl;
 
-import de.drolpi.conversion.core.converter.Converter;
+import de.drolpi.conversion.core.converter.NonGenericConverter;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Type;
+import java.util.Set;
 
-public final class EnumToIntegerConverter implements Converter<Enum<?>, Integer> {
+public final class EnumToIntegerConverter implements NonGenericConverter {
 
     @Override
-    public @NotNull Integer convert(@NotNull Enum<?> source, @NotNull Type sourceType, @NotNull Type targetType) {
-        return source.ordinal();
+    public @Nullable Object convert(@Nullable Object source, @NotNull Type sourceType, @NotNull Type targetType) {
+        if (!(source instanceof Enum<?> enumSource)) {
+            return null;
+        }
+
+        return enumSource.ordinal();
+    }
+
+    @Override
+    public boolean isSuitable(@NotNull Type sourceType, @NotNull Type targetType) {
+        return true;
+    }
+
+    @Override
+    public @NotNull Set<ConversionPath> paths() {
+        return Set.of(
+            new ConversionPath(Enum.class, Integer.class)
+        );
     }
 }

--- a/core/src/main/java/de/drolpi/conversion/core/impl/IntegerToEnumConverter.java
+++ b/core/src/main/java/de/drolpi/conversion/core/impl/IntegerToEnumConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2023 Lars Nippert
+ * Copyright 2023-2024 Lars Nippert
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,32 +17,37 @@
 package de.drolpi.conversion.core.impl;
 
 import de.drolpi.conversion.core.converter.NonGenericConverter;
+import io.leangen.geantyref.GenericTypeReflector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Type;
 import java.util.Set;
 
-public final class EnumToStringConverter implements NonGenericConverter {
-
-    @Override
-    public @Nullable Object convert(Object source, @NotNull Type sourceType, @NotNull Type targetType) {
-        if(!(source instanceof Enum<?> enumSource)) {
-            return null;
-        }
-
-        return enumSource.name();
-    }
+public class IntegerToEnumConverter implements NonGenericConverter {
 
     @Override
     public boolean isSuitable(@NotNull Type sourceType, @NotNull Type targetType) {
-        return true;
+        return false;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public @Nullable Object convert(@Nullable Object source, @NotNull Type sourceType, @NotNull Type targetType) {
+        if (source == null) {
+            return null;
+        }
+
+        final Integer identifier = (Integer) source;
+        final Class<? extends Enum> enumType = (Class<? extends Enum>) GenericTypeReflector.erase(targetType);
+
+        return enumType.getEnumConstants()[identifier];
     }
 
     @Override
     public @NotNull Set<ConversionPath> paths() {
         return Set.of(
-            new ConversionPath(Enum.class, String.class)
+            new ConversionPath(Integer.class, Enum.class)
         );
     }
 }

--- a/core/src/main/java/de/drolpi/conversion/core/impl/MapToMapConverter.java
+++ b/core/src/main/java/de/drolpi/conversion/core/impl/MapToMapConverter.java
@@ -18,6 +18,7 @@ package de.drolpi.conversion.core.impl;
 
 import de.drolpi.conversion.core.converter.NonGenericConverter;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Type;
 import java.util.Collections;
@@ -37,7 +38,7 @@ public final class MapToMapConverter implements NonGenericConverter {
     }
 
     @Override
-    public @NotNull Object convert(@NotNull Object source, @NotNull Type sourceType, @NotNull Type targetType) {
+    public @Nullable Object convert(Object source, @NotNull Type sourceType, @NotNull Type targetType) {
         return null;
     }
 }

--- a/core/src/main/java/de/drolpi/conversion/core/impl/NumberToNumberConverter.java
+++ b/core/src/main/java/de/drolpi/conversion/core/impl/NumberToNumberConverter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023-2024 Lars Nippert
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.drolpi.conversion.core.impl;
+
+import de.drolpi.conversion.core.converter.Converter;
+import de.drolpi.conversion.core.exception.ConversionFailedException;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public class NumberToNumberConverter implements Converter<Number, Number> {
+
+    private static final BigInteger LONG_MIN = BigInteger.valueOf(Long.MIN_VALUE);
+    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
+
+    @Override
+    public Number convert(Number source, @NotNull Type sourceType, @NotNull Type targetType) {
+        if (Byte.class == targetType) {
+            final long value = this.convertToLong(source, sourceType, targetType);
+            if (value >= Byte.MIN_VALUE && value <= Byte.MAX_VALUE) {
+                return source.byteValue();
+            }
+        } else if (Short.class == targetType) {
+            final long value = this.convertToLong(source, sourceType, targetType);
+            if (value >= Short.MIN_VALUE && value <= Short.MAX_VALUE) {
+                return source.shortValue();
+            }
+        } else if (Integer.class == targetType) {
+            final long value = this.convertToLong(source, sourceType, targetType);
+            if (value >= Integer.MIN_VALUE && value <= Integer.MAX_VALUE) {
+                return source.intValue();
+            }
+        } else if (Long.class == targetType) {
+            return this.convertToLong(source, sourceType, targetType);
+        } else if (BigInteger.class == targetType) {
+            if (source instanceof BigDecimal bigDecimal) {
+                return bigDecimal.toBigInteger();
+            } else {
+                return BigInteger.valueOf(source.longValue());
+            }
+        } else if (Float.class == targetType) {
+            return source.floatValue();
+        } else if (Double.class == targetType) {
+            return source.doubleValue();
+        } else if (BigDecimal.class == targetType) {
+            return new BigDecimal(source.toString());
+        }
+
+        throw new ConversionFailedException(sourceType, targetType, source);
+    }
+
+    private long convertToLong(final Number source, final Type sourceType, final Type targetType) {
+        final BigInteger bigInt = source instanceof BigInteger bigInteger ? bigInteger
+            : source instanceof BigDecimal bigDecimal ? bigDecimal.toBigInteger() : null;
+
+        if (bigInt == null || (bigInt.compareTo(LONG_MIN) >= 0 && bigInt.compareTo(LONG_MAX) <= 0)) {
+            return source.longValue();
+        }
+
+        throw new ConversionFailedException(sourceType, targetType, source);
+    }
+}

--- a/core/src/main/java/de/drolpi/conversion/core/impl/StringToEnumConverter.java
+++ b/core/src/main/java/de/drolpi/conversion/core/impl/StringToEnumConverter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023-2024 Lars Nippert
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.drolpi.conversion.core.impl;
+
+import de.drolpi.conversion.core.converter.NonGenericConverter;
+import io.leangen.geantyref.GenericTypeReflector;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Type;
+import java.util.Set;
+
+public class StringToEnumConverter implements NonGenericConverter {
+
+    private final IntegerToEnumConverter helpConverter = new IntegerToEnumConverter();
+
+    @Override
+    public boolean isSuitable(@NotNull Type sourceType, @NotNull Type targetType) {
+        return true;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public Object convert(Object source, @NotNull Type sourceType, @NotNull Type targetType) {
+        final String identifier = (String) source;
+
+        try {
+            int id = Integer.parseInt(identifier);
+            return this.helpConverter.convert(id, int.class, targetType);
+        } catch (NumberFormatException ignored) {
+
+        }
+
+        if (identifier.isEmpty()) {
+            // It's an empty enum identifier: reset the enum value to null.
+            return null;
+        }
+        final Class<? extends Enum> enumType = (Class<? extends Enum>) GenericTypeReflector.erase(targetType);
+        return Enum.valueOf(enumType, identifier.trim());
+    }
+
+    @Override
+    public @NotNull Set<ConversionPath> paths() {
+        return Set.of(
+            new ConversionPath(String.class, Enum.class)
+        );
+    }
+}

--- a/core/src/main/java/de/drolpi/conversion/core/util/ClassCollectorUtil.java
+++ b/core/src/main/java/de/drolpi/conversion/core/util/ClassCollectorUtil.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023-2023 Lars Nippert
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.drolpi.conversion.core.util;
+
+import io.leangen.geantyref.GenericTypeReflector;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public final class ClassCollectorUtil {
+
+    private ClassCollectorUtil() {
+        throw new RuntimeException();
+    }
+
+    public static @NotNull List<Class<?>> classTree(@NotNull final Type type) {
+        final Class<?> erasedType = GenericTypeReflector.erase(GenericTypeReflector.box(type));
+        final List<Class<?>> tree = new ArrayList<>(20);
+        final Set<Class<?>> visited = new HashSet<>(20);
+
+        collectClass(0, erasedType, false, tree, visited);
+        final boolean array = erasedType.isArray();
+
+        // Walk through super class tree
+        for (int i = 0; i < tree.size(); i++) {
+            Class<?> candidate = tree.get(i);
+            candidate = (array ? candidate.componentType() : candidate);
+
+            // Collect
+            final Class<?> superclass = candidate.getSuperclass();
+            if (superclass != null && superclass != Object.class && superclass != Enum.class) {
+                collectClass(i + 1, candidate.getSuperclass(), array, tree, visited);
+            }
+            collectInterfaces(candidate, array, tree, visited);
+        }
+
+        // Check whether the type is an enum or not
+        if (Enum.class.isAssignableFrom(erasedType)) {
+            collectClass(tree.size(), Enum.class, array, tree, visited);
+            collectClass(tree.size(), Enum.class, false, tree, visited);
+            collectInterfaces(Enum.class, array, tree, visited);
+        }
+
+        // Add object type
+        collectClass(tree.size(), Object.class, array, tree, visited);
+        collectClass(tree.size(), Object.class, false, tree, visited);
+        return tree;
+    }
+
+    private static void collectInterfaces(@NotNull final Class<?> type, final boolean asArray,
+        @NotNull final List<Class<?>> hierarchy, @NotNull final Set<Class<?>> visited
+    ) {
+        for (final Class<?> implementedInterface : type.getInterfaces()) {
+            collectClass(hierarchy.size(), implementedInterface, asArray, hierarchy, visited);
+        }
+    }
+
+    private static void collectClass(int index, @NotNull Class<?> type, boolean asArray,
+        @NotNull final List<Class<?>> hierarchy, @NotNull final Set<Class<?>> visited
+    ) {
+        if (asArray) {
+            type = type.arrayType();
+        }
+        if (visited.add(type)) {
+            hierarchy.add(index, type);
+        }
+    }
+}

--- a/core/src/main/java/de/drolpi/conversion/core/util/Types.java
+++ b/core/src/main/java/de/drolpi/conversion/core/util/Types.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023-2024 Lars Nippert
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.drolpi.conversion.core.util;
+
+import io.leangen.geantyref.TypeFactory;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static io.leangen.geantyref.GenericTypeReflector.erase;
+
+public final class Types {
+
+    private Types() {
+        throw new RuntimeException();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Class<List<T>> list(Class<T> value) {
+        return (Class<List<T>>) erase(TypeFactory.parameterizedClass(List.class, value));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T, U> Class<Map<T, U>> map(Class<T> key, Class<U> value) {
+        return (Class<Map<T, U>>) erase(TypeFactory.parameterizedClass(Map.class, key, value));
+    }
+}

--- a/object-mapper/build.gradle.kts
+++ b/object-mapper/build.gradle.kts
@@ -1,0 +1,3 @@
+dependencies {
+    "implementation"(projects.core)
+}

--- a/object-mapper/src/main/java/de/drolpi/conversion/core/DefaultObjectMappingConversionBus.java
+++ b/object-mapper/src/main/java/de/drolpi/conversion/core/DefaultObjectMappingConversionBus.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023-2024 Lars Nippert
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.drolpi.conversion.core;
+
+import de.drolpi.conversion.objectmapper.ObjectMapper;
+import de.drolpi.conversion.objectmapper.impl.MapToObjectConverter;
+import de.drolpi.conversion.objectmapper.impl.ObjectToMapConverter;
+import de.drolpi.conversion.objectmapper.impl.ObjectToObjectConverter;
+
+public class DefaultObjectMappingConversionBus extends DefaultConversionBus implements ObjectMappingConversionBus {
+
+    public DefaultObjectMappingConversionBus() {
+        super();
+        DefaultObjectMappingConversionBus.registerDefaults(this);
+    }
+
+    public static void registerDefaults(ConfigurableConversionBus bus) {
+        final ObjectMapper.Factory factory = ObjectMapper.factory();
+        bus.register(new ObjectToMapConverter(factory));
+        bus.register(new MapToObjectConverter(factory));
+        bus.register(new ObjectToObjectConverter(factory));
+    }
+}

--- a/object-mapper/src/main/java/de/drolpi/conversion/core/ObjectMappingAlgorithmConversionBus.java
+++ b/object-mapper/src/main/java/de/drolpi/conversion/core/ObjectMappingAlgorithmConversionBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2023 Lars Nippert
+ * Copyright 2023-2024 Lars Nippert
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,10 @@
 
 package de.drolpi.conversion.core;
 
-import de.drolpi.conversion.core.converter.Converter;
-import de.drolpi.conversion.core.converter.NonGenericConverter;
-import org.jetbrains.annotations.NotNull;
+public class ObjectMappingAlgorithmConversionBus extends DefaultAlgorithmConversionBus implements ObjectMappingConversionBus {
 
-public interface ConverterRegistry {
-
-    <U, V> void register(@NotNull Class<? extends U> source, @NotNull Class<V> target, @NotNull Converter<U, V> converter);
-
-    void register(@NotNull NonGenericConverter converter);
-
-    void unregister(@NotNull Class<?> source, @NotNull Class<?> target);
-
-    void unregister(@NotNull NonGenericConverter converter);
+    public ObjectMappingAlgorithmConversionBus() {
+        super();
+        DefaultObjectMappingConversionBus.registerDefaults(this);
+    }
 }

--- a/object-mapper/src/main/java/de/drolpi/conversion/core/ObjectMappingConversionBus.java
+++ b/object-mapper/src/main/java/de/drolpi/conversion/core/ObjectMappingConversionBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2023 Lars Nippert
+ * Copyright 2023-2024 Lars Nippert
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,13 @@
 
 package de.drolpi.conversion.core;
 
-import de.drolpi.conversion.core.converter.Converter;
-import de.drolpi.conversion.core.converter.NonGenericConverter;
-import org.jetbrains.annotations.NotNull;
+public interface ObjectMappingConversionBus extends ConfigurableConversionBus {
 
-public interface ConverterRegistry {
+    static ObjectMappingConversionBus createDefault() {
+        return new DefaultObjectMappingConversionBus();
+    }
 
-    <U, V> void register(@NotNull Class<? extends U> source, @NotNull Class<V> target, @NotNull Converter<U, V> converter);
-
-    void register(@NotNull NonGenericConverter converter);
-
-    void unregister(@NotNull Class<?> source, @NotNull Class<?> target);
-
-    void unregister(@NotNull NonGenericConverter converter);
+    static ObjectMappingConversionBus createAlgorithmDefault() {
+        return new ObjectMappingAlgorithmConversionBus();
+    }
 }

--- a/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/ObjectMapper.java
+++ b/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/ObjectMapper.java
@@ -16,6 +16,8 @@
 
 package de.drolpi.conversion.objectmapper;
 
+import de.drolpi.conversion.core.ConversionBus;
+import de.drolpi.conversion.objectmapper.discoverer.FieldDiscoverer;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Type;
@@ -24,11 +26,11 @@ import java.util.Map;
 public interface ObjectMapper<T> {
 
     static @NotNull Factory factory() {
-        return null;
+        return ObjectMapperFactoryImpl.INSTANCE;
     }
 
     static @NotNull Factory.Builder factoryBuilder() {
-        return null;
+        return new ObjectMapperFactoryImpl.BuilderImpl();
     }
 
     T load(Map<String, Object> source);
@@ -37,9 +39,18 @@ public interface ObjectMapper<T> {
 
     interface Factory {
 
+        @SuppressWarnings("unchecked")
+        default @NotNull <T> ObjectMapper<T> get(@NotNull Class<T> type) {
+            return (ObjectMapper<T>) this.get((Type) type);
+        }
+
         @NotNull ObjectMapper<?> get(@NotNull Type type);
 
         interface Builder {
+
+            @NotNull Builder addDiscoverer(@NotNull FieldDiscoverer<?> discoverer);
+
+            @NotNull Builder conversionBus(@NotNull ConversionBus conversionBus);
 
             @NotNull ObjectMapper.Factory build();
 

--- a/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/ObjectMapperFactoryImpl.java
+++ b/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/ObjectMapperFactoryImpl.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023-2023 Lars Nippert
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.drolpi.conversion.objectmapper;
+
+import de.drolpi.conversion.core.ConversionBus;
+import de.drolpi.conversion.objectmapper.discoverer.FieldDiscoverer;
+import de.drolpi.conversion.objectmapper.discoverer.RecordFieldDiscoverer;
+import io.leangen.geantyref.GenericTypeReflector;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class ObjectMapperFactoryImpl implements ObjectMapper.Factory {
+
+    static final ObjectMapper.Factory INSTANCE = ObjectMapper.factoryBuilder().addDiscoverer(FieldDiscoverer.create()).addDiscoverer(new RecordFieldDiscoverer()).build();
+    private static final int MAXIMUM_MAPPERS_SIZE = 64;
+
+    private final Map<Type, ObjectMapper<?>> mappers = new LinkedHashMap<>() {
+        @Override
+        protected boolean removeEldestEntry(final Map.Entry<Type, ObjectMapper<?>> eldest) {
+            return this.size() > MAXIMUM_MAPPERS_SIZE;
+        }
+    };
+    private final List<FieldDiscoverer<?>> fieldDiscoverers;
+    private final ConversionBus conversionBus;
+
+    ObjectMapperFactoryImpl(final BuilderImpl builder) {
+        this.fieldDiscoverers = new ArrayList<>(builder.discoverer);
+        this.conversionBus = builder.conversionBus;
+    }
+
+    @Override
+    public @NotNull ObjectMapper<?> get(@NotNull final Type type) {
+        // Check if type is missing type parameters
+        if (GenericTypeReflector.isMissingTypeParameters(type)) {
+            throw new RuntimeException("Raw types are not supported!");
+        }
+
+        synchronized (this.mappers) {
+            // Check if we already have cached a suitable object mapper
+            ObjectMapper<?> objectMapper = this.mappers.get(type);
+
+            if (objectMapper != null) {
+                return objectMapper;
+            }
+
+            // Iterate through all field discoverers and if we can create an object mapper
+            for (final FieldDiscoverer<?> discoverer : this.fieldDiscoverers) {
+                if (!discoverer.isSuitable(type)) {
+                    continue;
+                }
+
+                // Create an object mapper
+                objectMapper = this.createMapper(type, discoverer);
+                this.mappers.put(type, objectMapper);
+                return objectMapper;
+            }
+
+            //TODO: Replace with own exception
+            throw new RuntimeException();
+        }
+    }
+
+    private <T, U> ObjectMapper<T> createMapper(final Type type, final FieldDiscoverer<U> discoverer) {
+        final FieldDiscoverer.DataApplier<U> applier = discoverer.createDataApplier(type);
+        final List<FieldDiscoverer.FieldData<T, U>> fields = new ArrayList<>();
+        discoverer.discoverFields(type, fields);
+
+        return new ObjectMapperImpl<>(fields, applier, this.conversionBus);
+    }
+
+    static final class BuilderImpl implements ObjectMapper.Factory.Builder {
+
+        private final List<FieldDiscoverer<?>> discoverer = new ArrayList<>();
+        private ConversionBus conversionBus = ConversionBus.createDefault();
+
+        @Override
+        public @NotNull Builder addDiscoverer(@NotNull final FieldDiscoverer<?> discoverer) {
+            this.discoverer.add(discoverer);
+            return this;
+        }
+
+        @Override
+        public @NotNull Builder conversionBus(@NotNull final ConversionBus conversionBus) {
+            this.conversionBus = conversionBus;
+            return this;
+        }
+
+        @Override
+        public ObjectMapper.@NotNull Factory build() {
+            return new ObjectMapperFactoryImpl(this);
+        }
+    }
+}

--- a/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/ObjectMapperImpl.java
+++ b/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/ObjectMapperImpl.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023-2023 Lars Nippert
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.drolpi.conversion.objectmapper;
+
+import de.drolpi.conversion.core.ConversionBus;
+import de.drolpi.conversion.objectmapper.discoverer.FieldDiscoverer;
+import io.leangen.geantyref.GenericTypeReflector;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+@SuppressWarnings({"ClassCanBeRecord", "unchecked"})
+final class ObjectMapperImpl<T, U> implements ObjectMapper<T> {
+
+    //TODO: Add methods to interface
+
+    private final List<FieldDiscoverer.FieldData<T, U>> fieldData;
+    private final FieldDiscoverer.DataApplier<U> dataApplier;
+    private final ConversionBus conversionBus;
+
+    ObjectMapperImpl(List<FieldDiscoverer.FieldData<T, U>> fieldData, FieldDiscoverer.DataApplier<U> dataApplier, ConversionBus conversionBus) {
+        this.fieldData = Collections.unmodifiableList(fieldData);
+        this.dataApplier = dataApplier;
+        this.conversionBus = conversionBus;
+    }
+
+    @Override
+    public T load(Map<String, Object> source) {
+        return this.load(source, intermediate -> (T) this.dataApplier.complete(intermediate));
+    }
+
+    public void load(T value, Map<String, Object> source) {
+        this.load(source, intermediate -> {
+            this.dataApplier.complete(value, intermediate);
+            return value;
+        });
+    }
+
+    private T load(Map<String, Object> source, Function<U, T> completer) {
+        final U fieldData = this.dataApplier.begin();
+
+        // Iterate through all fields
+        for (final FieldDiscoverer.FieldData<T, U> field : this.fieldData) {
+            // Get value from map
+            final Object mapValue = source.get(field.name());
+
+            if (mapValue == null) {
+                continue;
+            }
+
+            final Type fieldType = field.type();
+            final Class<?> erasedBoxedType = GenericTypeReflector.erase(GenericTypeReflector.box(fieldType));
+            // Convert value to field type
+            final Object fieldValue = this.conversionBus.convert(mapValue, fieldType);
+
+            if (!erasedBoxedType.isInstance(fieldValue)) {
+                throw new RuntimeException("Object " + fieldValue + " is not of expected type " + fieldType);
+            }
+            // Set converted value
+            field.deserializer().accept(fieldData, fieldValue);
+        }
+
+        return completer.apply(fieldData);
+    }
+
+    @Override
+    public Map<String, Object> save(T value) {
+        final Map<String, Object> target = new HashMap<>();
+
+        this.save(target, value);
+        return target;
+    }
+
+    public void save(Map<String, Object> target, T value) {
+        // Iterate through all fields
+        for (final FieldDiscoverer.FieldData<T, U> fieldData : this.fieldData) {
+            // Get value from field
+            final Object fieldValue = fieldData.serializer().apply(value);
+
+            if (fieldValue == null) {
+                target.put(fieldData.name(), null);
+                continue;
+            }
+
+            //TODO:
+            //final Object mapValue = this.conversionBus.convertToObject(fieldValue);
+
+            // Store value in map
+            target.put(fieldData.name(), fieldValue);
+        }
+    }
+}

--- a/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/discoverer/FieldDiscoverer.java
+++ b/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/discoverer/FieldDiscoverer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023-2023 Lars Nippert
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.drolpi.conversion.objectmapper.discoverer;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public interface FieldDiscoverer<T> {
+
+    static @NotNull FieldDiscoverer<?> create() {
+        return ObjectFieldDiscoverer.EMPTY_CONSTRUCTOR_INSTANCE;
+    }
+
+    static @NotNull FieldDiscoverer<?> create(@NotNull Function<Type, Supplier<Object>> instanceFactory) {
+        return new ObjectFieldDiscoverer(instanceFactory, true);
+    }
+
+    boolean isSuitable(@NotNull Type type);
+
+    <U> void discoverFields(@NotNull Type type, List<FieldData<U, T>> fields);
+
+    DataApplier<T> createDataApplier(@NotNull Type type);
+
+    interface DataApplier<T> {
+
+        T begin();
+
+        void complete(Object value, T intermediate);
+
+        Object complete(T intermediate);
+
+    }
+
+    record Result<T, U>(List<FieldData<T, U>> fieldData, DataApplier<U> dataApplier) {
+
+    }
+
+    record FieldData<T, U>(String name, Type type, Deserializer<U> deserializer, Serializer<T> serializer) {
+
+        public interface Deserializer<T> extends BiConsumer<T, Object> {
+
+        }
+
+        public interface Serializer<T> extends Function<T, Object> {
+
+        }
+    }
+
+}

--- a/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/discoverer/ObjectFieldDiscoverer.java
+++ b/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/discoverer/ObjectFieldDiscoverer.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023-2023 Lars Nippert
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.drolpi.conversion.objectmapper.discoverer;
+
+import de.drolpi.conversion.core.util.ClassCollectorUtil;
+import io.leangen.geantyref.GenericTypeReflector;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+@SuppressWarnings("ClassCanBeRecord")
+public class ObjectFieldDiscoverer implements FieldDiscoverer<Map<Field, Object>> {
+
+    static final ObjectFieldDiscoverer EMPTY_CONSTRUCTOR_INSTANCE = new ObjectFieldDiscoverer(new EmptyConstructorFactory(), false);
+
+    private final Function<Type, Supplier<Object>> instanceFactory;
+    private final boolean requiresInstanceCreation;
+
+    ObjectFieldDiscoverer(Function<Type, Supplier<Object>> instanceFactory, boolean requiresInstanceCreation) {
+        this.instanceFactory = instanceFactory;
+        this.requiresInstanceCreation = requiresInstanceCreation;
+    }
+
+    @Override
+    public boolean isSuitable(@NotNull Type type) {
+        final Class<?> erasedTargetType = GenericTypeReflector.erase(type);
+        return !erasedTargetType.isInterface() && !erasedTargetType.isRecord();
+    }
+
+    @Override
+    public <U> void discoverFields(@NotNull Type type, List<FieldData<U, Map<Field, Object>>> fields) {
+        final List<Class<?>> sourceTree = ClassCollectorUtil.classTree(type);
+
+        for (final Class<?> collectClass : sourceTree) {
+            for (final Field field : collectClass.getDeclaredFields()) {
+                // Check if field is static or transient
+                if ((field.getModifiers() & (Modifier.STATIC | Modifier.TRANSIENT)) != 0) {
+                    continue;
+                }
+
+                field.setAccessible(true);
+                // Store field data
+                fields.add(new FieldData<>(field.getName(), field.getType(), (intermediate, value) -> intermediate.put(field, value), u -> {
+                    try {
+                        return field.get(u);
+                    } catch (IllegalAccessException e) {
+                        throw new RuntimeException(e);
+                    }
+                }));
+            }
+        }
+    }
+
+    @Override
+    public DataApplier<Map<Field, Object>> createDataApplier(@NotNull Type type) {
+        final Supplier<Object> maker = this.instanceFactory.apply(type);
+        if (maker == null && this.requiresInstanceCreation) {
+            throw new RuntimeException();
+        }
+
+        return new DataApplier<>() {
+            @Override
+            public Map<Field, Object> begin() {
+                return new HashMap<>();
+            }
+
+            @Override
+            public void complete(final Object instance, final Map<Field, Object> fieldData) {
+                for (final Map.Entry<Field, Object> entry : fieldData.entrySet()) {
+                    try {
+                        entry.getKey().set(instance, entry.getValue());
+                    } catch (final IllegalAccessException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+
+            @Override
+            public Object complete(final Map<Field, Object> fieldData) {
+                final Object instance = maker == null ? null : maker.get();
+                if (instance == null) {
+                    throw new RuntimeException("Unable to create instances for this type");
+                }
+                this.complete(instance, fieldData);
+                return instance;
+            }
+        };
+    }
+
+    private static final class EmptyConstructorFactory implements Function<Type, Supplier<Object>> {
+
+        @Override
+        public Supplier<Object> apply(final Type type) {
+            try {
+                final Constructor<?> constructor = GenericTypeReflector.erase(type).getDeclaredConstructor();
+                constructor.setAccessible(true);
+                return () -> {
+                    try {
+                        return constructor.newInstance();
+                    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                        throw new RuntimeException(e);
+                    }
+                };
+            } catch (final NoSuchMethodException ignored) {
+                return null;
+            }
+        }
+    }
+}

--- a/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/discoverer/RecordFieldDiscoverer.java
+++ b/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/discoverer/RecordFieldDiscoverer.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023-2023 Lars Nippert
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.drolpi.conversion.objectmapper.discoverer;
+
+import io.leangen.geantyref.GenericTypeReflector;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.RecordComponent;
+import java.lang.reflect.Type;
+import java.util.List;
+
+public class RecordFieldDiscoverer implements FieldDiscoverer<Object[]> {
+
+    @Override
+    public boolean isSuitable(@NotNull Type type) {
+        final Class<?> erasedType = GenericTypeReflector.erase(type);
+        return erasedType.isRecord();
+    }
+
+    @Override
+    public <U> void discoverFields(@NotNull Type type, List<FieldData<U, Object[]>> fields) {
+        final Class<?> clazz = GenericTypeReflector.erase(type);
+        final RecordComponent[] recordComponents = clazz.getRecordComponents();
+
+        for (int i = 0, recordComponentsLength = recordComponents.length; i < recordComponentsLength; i++) {
+            final RecordComponent component = recordComponents[i];
+            final Method accessor = component.getAccessor();
+            accessor.setAccessible(true);
+
+            final String name = component.getName();
+            final Type genericType = component.getType();
+
+            final Type resolvedType = GenericTypeReflector.resolveExactType(genericType, type);
+            final int targetIdx = i;
+            fields.add(new FieldData<>(name, GenericTypeReflector.erase(resolvedType), (intermediate, value) -> intermediate[targetIdx] = value,
+                value -> {
+                    try {
+                        return accessor.invoke(value);
+                    } catch (IllegalAccessException | InvocationTargetException e) {
+                        throw new RuntimeException(e);
+                    }
+                }));
+        }
+    }
+
+    @Override
+    public DataApplier<Object[]> createDataApplier(@NotNull Type type) {
+        final Class<?> clazz = GenericTypeReflector.erase(type);
+        final RecordComponent[] recordComponents = clazz.getRecordComponents();
+        final Class<?>[] constructorParams = new Class<?>[recordComponents.length];
+
+        for (int i = 0, recordComponentsLength = recordComponents.length; i < recordComponentsLength; i++) {
+            final RecordComponent component = recordComponents[i];
+            final Type genericType = component.getType();
+            constructorParams[i] = GenericTypeReflector.erase(genericType);
+        }
+
+        // canonical constructor, which we'll use to make new instances
+        final Constructor<?> clazzConstructor;
+        try {
+            clazzConstructor = clazz.getDeclaredConstructor(constructorParams);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+        clazzConstructor.setAccessible(true);
+
+        return new DataApplier<>() {
+            @Override
+            public Object[] begin() {
+                return new Object[recordComponents.length];
+            }
+
+            @Override
+            public void complete(Object value, Object[] intermediate) {
+
+            }
+
+            @Override
+            public Object complete(Object[] intermediate) {
+                try {
+                    return clazzConstructor.newInstance(intermediate);
+                } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+}

--- a/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/impl/AbstractObjectMappingConverter.java
+++ b/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/impl/AbstractObjectMappingConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023-2024 Lars Nippert
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.drolpi.conversion.objectmapper.impl;
+
+import de.drolpi.conversion.objectmapper.ObjectMapper;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+public abstract class AbstractObjectMappingConverter {
+
+    protected final ObjectMapper.Factory factory;
+
+    public AbstractObjectMappingConverter(ObjectMapper.Factory factory) {
+        this.factory = factory;
+    }
+
+    protected boolean isMapSuitable(@NotNull Type type) {
+        if (!(type instanceof ParameterizedType parameterizedType)) {
+            //TODO: is this unsafe?
+            return true;
+        }
+
+        final Type[] typeArgs = parameterizedType.getActualTypeArguments();
+
+        if (typeArgs.length != 2) {
+            return false;
+        }
+
+        return typeArgs[0].equals(String.class) && typeArgs[1].equals(Object.class);
+    }
+}

--- a/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/impl/MapToObjectConverter.java
+++ b/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/impl/MapToObjectConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2023 Lars Nippert
+ * Copyright 2023-2024 Lars Nippert
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,35 +14,43 @@
  * limitations under the License.
  */
 
-package de.drolpi.conversion.core.impl;
+package de.drolpi.conversion.objectmapper.impl;
 
 import de.drolpi.conversion.core.converter.NonGenericConverter;
+import de.drolpi.conversion.objectmapper.ObjectMapper;
+import io.leangen.geantyref.TypeToken;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Map;
 import java.util.Set;
 
-public final class EnumToStringConverter implements NonGenericConverter {
+public class MapToObjectConverter extends AbstractObjectMappingConverter implements NonGenericConverter {
 
+    public MapToObjectConverter(ObjectMapper.Factory factory) {
+        super(factory);
+    }
+
+    @SuppressWarnings("unchecked")
     @Override
-    public @Nullable Object convert(Object source, @NotNull Type sourceType, @NotNull Type targetType) {
-        if(!(source instanceof Enum<?> enumSource)) {
-            return null;
-        }
+    public @Nullable Object convert(@Nullable Object source, @NotNull Type sourceType, @NotNull Type targetType) {
+        final Map<String, Object> sourceMap = (Map<String, Object>) source;
+        final ObjectMapper<Object> objectMapper = (ObjectMapper<Object>) this.factory.get(targetType);
 
-        return enumSource.name();
+        return objectMapper.load(sourceMap);
     }
 
     @Override
     public boolean isSuitable(@NotNull Type sourceType, @NotNull Type targetType) {
-        return true;
+        return this.isMapSuitable(sourceType);
     }
 
     @Override
     public @NotNull Set<ConversionPath> paths() {
         return Set.of(
-            new ConversionPath(Enum.class, String.class)
+            new ConversionPath(Map.class, Object.class)
         );
     }
 }

--- a/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/impl/ObjectToMapConverter.java
+++ b/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/impl/ObjectToMapConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2023 Lars Nippert
+ * Copyright 2023-2024 Lars Nippert
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,35 +14,40 @@
  * limitations under the License.
  */
 
-package de.drolpi.conversion.core.impl;
+package de.drolpi.conversion.objectmapper.impl;
 
 import de.drolpi.conversion.core.converter.NonGenericConverter;
+import de.drolpi.conversion.objectmapper.ObjectMapper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Type;
+import java.util.Map;
 import java.util.Set;
 
-public final class EnumToStringConverter implements NonGenericConverter {
+public class ObjectToMapConverter extends AbstractObjectMappingConverter implements NonGenericConverter {
 
+    public ObjectToMapConverter(ObjectMapper.Factory factory) {
+        super(factory);
+    }
+
+    @SuppressWarnings("unchecked")
     @Override
-    public @Nullable Object convert(Object source, @NotNull Type sourceType, @NotNull Type targetType) {
-        if(!(source instanceof Enum<?> enumSource)) {
-            return null;
-        }
+    public @Nullable Object convert(@Nullable Object source, @NotNull Type sourceType, @NotNull Type targetType) {
+        final ObjectMapper<Object> objectMapper = (ObjectMapper<Object>) this.factory.get(sourceType);
 
-        return enumSource.name();
+        return objectMapper.save(source);
     }
 
     @Override
     public boolean isSuitable(@NotNull Type sourceType, @NotNull Type targetType) {
-        return true;
+        return this.isMapSuitable(targetType);
     }
 
     @Override
     public @NotNull Set<ConversionPath> paths() {
         return Set.of(
-            new ConversionPath(Enum.class, String.class)
+            new ConversionPath(Object.class, Map.class)
         );
     }
 }

--- a/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/impl/ObjectToObjectConverter.java
+++ b/object-mapper/src/main/java/de/drolpi/conversion/objectmapper/impl/ObjectToObjectConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2023 Lars Nippert
+ * Copyright 2023-2024 Lars Nippert
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,31 @@
  * limitations under the License.
  */
 
-package de.drolpi.conversion.core.impl;
+package de.drolpi.conversion.objectmapper.impl;
 
 import de.drolpi.conversion.core.converter.NonGenericConverter;
+import de.drolpi.conversion.objectmapper.ObjectMapper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Type;
+import java.util.Map;
 import java.util.Set;
 
-public final class EnumToStringConverter implements NonGenericConverter {
+public class ObjectToObjectConverter extends AbstractObjectMappingConverter implements NonGenericConverter {
 
+    public ObjectToObjectConverter(ObjectMapper.Factory factory) {
+        super(factory);
+    }
+
+    @SuppressWarnings("unchecked")
     @Override
-    public @Nullable Object convert(Object source, @NotNull Type sourceType, @NotNull Type targetType) {
-        if(!(source instanceof Enum<?> enumSource)) {
-            return null;
-        }
+    public @Nullable Object convert(@Nullable Object source, @NotNull Type sourceType, @NotNull Type targetType) {
+        final ObjectMapper<Object> sourceMapper = (ObjectMapper<Object>) this.factory.get(sourceType);
+        final ObjectMapper<Object> targetMapper = (ObjectMapper<Object>) this.factory.get(targetType);
 
-        return enumSource.name();
+        final Map<String, Object> map = sourceMapper.save(source);
+        return targetMapper.load(map);
     }
 
     @Override
@@ -42,7 +49,7 @@ public final class EnumToStringConverter implements NonGenericConverter {
     @Override
     public @NotNull Set<ConversionPath> paths() {
         return Set.of(
-            new ConversionPath(Enum.class, String.class)
+            new ConversionPath(Object.class, Object.class)
         );
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,5 +28,6 @@ pluginManagement {
 rootProject.name = "Conversion"
 
 include(
-        ":core"
+        ":core",
+        ":object-mapper"
 )

--- a/src/main/java/de/drolpi/conversion/objectmapper/ObjectMapper.java
+++ b/src/main/java/de/drolpi/conversion/objectmapper/ObjectMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023-2023 Lars Nippert
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.drolpi.conversion.objectmapper;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+public interface ObjectMapper<T> {
+
+    static @NotNull Factory factory() {
+        return null;
+    }
+
+    static @NotNull Factory.Builder factoryBuilder() {
+        return null;
+    }
+
+    T load(Map<String, Object> source);
+
+    Map<String, Object> save(T source);
+
+    interface Factory {
+
+        @NotNull ObjectMapper<?> get(@NotNull Type type);
+
+        interface Builder {
+
+            @NotNull ObjectMapper.Factory build();
+
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
It is currently not possible to convert objects from user-defined classes or data classes for which no converter is registered.

### Modification
Add an object mapper that can convert objects into maps and back. This is then implemented in 3 converters so far: Object to Map, Map to Object and Object via Map to Object

### Result
It is now possible to convert objects to maps, maps to objects and objects of class A to objects of class B
